### PR TITLE
[#6] - Fixed strict node engine version break with different node version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.3
+
+#### Fixes
+
+* Fixed strict node engine version break with different node version [#6](https://github.com/yoriiis/vlitejs/issues/6)
+
+
 # 3.0.2
 
 #### Updates

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     </a>
 </p><br /><br />
 <p align="center">
-    <img alt="TravisCI" src="https://img.shields.io/badge/vLitejs-v3.0.2-ff7f15.svg?style=for-the-badge">
+    <img alt="TravisCI" src="https://img.shields.io/badge/vLitejs-v3.0.3-ff7f15.svg?style=for-the-badge">
     <a href="https://travis-ci.com/yoriiis/vlitejs">
         <img alt="TravisCI" src="https://img.shields.io/travis/yoriiis/vlitejs?style=for-the-badge">
     </a>
@@ -16,7 +16,7 @@
     <a href="https://bundlephobia.com/result?p=fela@latest">
         <img alt="Bundlephobia" src="https://img.shields.io/bundlephobia/minzip/vlitejs?style=for-the-badge">
     </a>
-    <a href="https://npmjs.com/package/chunks-webpack-plugin">
+    <a href="https://npmjs.com/package/vlitejs">
         <img alt="Npm downloads" src="https://img.shields.io/npm/dm/vlitejs?color=fb3e44&label=npm%20downloads&style=for-the-badge">
     </a>
 </p>
@@ -55,6 +55,7 @@ Online demo is available on [yoriiis.github.io/vlitejs/demo](https://yoriiis.git
 The project includes also several examples of vLitejs implementation.
 
 ## How it works
+
 HTML5 and Youtube video players use the same minimalist structure with native HTML5 `<video>` tag.
 
 ### HTML5 video

--- a/dist/vlite/js/vlite.js
+++ b/dist/vlite/js/vlite.js
@@ -2,7 +2,7 @@
 /**
 * @license MIT
 * @name vlitejs
-* @version 3.0.2
+* @version 3.0.3
 * @author: Yoriiis aka Joris DANIEL <joris.daniel@gmail.com>
 * @description: vLitejs is a fast and lightweight Javascript library for customizing HTML5 and Youtube video players in Javascript with a minimalist theme
 * {@link https://yoriiis.github.io/vlitejs}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,14 +26,13 @@ Includes files manually in your project:
 
 ```html
 <link rel="stylesheet" href="vlite.css" />
-<script src="vlitejs"></script>
+<script src="vlite.js"></script>
 
 <script>
     new vlitejs({
         selector: '#player'
     });
 </script>
-
 ```
 
 <script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vlitejs",
-	"version": "3.0.0",
+	"version": "3.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1205,10 +1205,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ajv-errors": {
@@ -2282,7 +2282,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "^0.2.0"
+				"callsites": "0.2.0"
 			}
 		},
 		"callsites": {
@@ -3851,7 +3851,7 @@
 			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
 			"dev": true,
 			"requires": {
-				"esutils": "^2.0.2"
+				"esutils": "2.0.3"
 			}
 		},
 		"doiuse": {
@@ -4301,43 +4301,43 @@
 			"integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"babel-code-frame": "^6.22.0",
-				"chalk": "^2.1.0",
-				"concat-stream": "^1.6.0",
-				"cross-spawn": "^5.1.0",
-				"debug": "^3.1.0",
-				"doctrine": "^2.1.0",
-				"eslint-scope": "^3.7.1",
-				"eslint-visitor-keys": "^1.0.0",
-				"espree": "^3.5.2",
-				"esquery": "^1.0.0",
-				"esutils": "^2.0.2",
-				"file-entry-cache": "^2.0.0",
-				"functional-red-black-tree": "^1.0.1",
-				"glob": "^7.1.2",
-				"globals": "^11.0.1",
-				"ignore": "^3.3.3",
-				"imurmurhash": "^0.1.4",
-				"inquirer": "^3.0.6",
-				"is-resolvable": "^1.0.0",
-				"js-yaml": "^3.9.1",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.3.0",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.2",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
-				"path-is-inside": "^1.0.2",
-				"pluralize": "^7.0.0",
-				"progress": "^2.0.0",
-				"require-uncached": "^1.0.3",
-				"semver": "^5.3.0",
-				"strip-ansi": "^4.0.0",
-				"strip-json-comments": "~2.0.1",
+				"ajv": "5.5.2",
+				"babel-code-frame": "6.26.0",
+				"chalk": "2.4.2",
+				"concat-stream": "1.6.2",
+				"cross-spawn": "5.1.0",
+				"debug": "3.2.6",
+				"doctrine": "2.1.0",
+				"eslint-scope": "3.7.3",
+				"eslint-visitor-keys": "1.1.0",
+				"espree": "3.5.4",
+				"esquery": "1.0.1",
+				"esutils": "2.0.3",
+				"file-entry-cache": "2.0.0",
+				"functional-red-black-tree": "1.0.1",
+				"glob": "7.1.6",
+				"globals": "11.12.0",
+				"ignore": "3.3.10",
+				"imurmurhash": "0.1.4",
+				"inquirer": "3.3.0",
+				"is-resolvable": "1.1.0",
+				"js-yaml": "3.13.1",
+				"json-stable-stringify-without-jsonify": "1.0.1",
+				"levn": "0.3.0",
+				"lodash": "4.17.15",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"optionator": "0.8.3",
+				"path-is-inside": "1.0.2",
+				"pluralize": "7.0.0",
+				"progress": "2.0.3",
+				"require-uncached": "1.0.3",
+				"semver": "5.7.1",
+				"strip-ansi": "4.0.0",
+				"strip-json-comments": "2.0.1",
 				"table": "4.0.2",
-				"text-table": "~0.2.0"
+				"text-table": "0.2.0"
 			},
 			"dependencies": {
 				"ajv-keywords": {
@@ -4358,9 +4358,9 @@
 					"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
+						"chalk": "1.1.3",
+						"esutils": "2.0.3",
+						"js-tokens": "3.0.2"
 					},
 					"dependencies": {
 						"chalk": {
@@ -4369,11 +4369,11 @@
 							"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 							"dev": true,
 							"requires": {
-								"ansi-styles": "^2.2.1",
-								"escape-string-regexp": "^1.0.2",
-								"has-ansi": "^2.0.0",
-								"strip-ansi": "^3.0.0",
-								"supports-color": "^2.0.0"
+								"ansi-styles": "2.2.1",
+								"escape-string-regexp": "1.0.5",
+								"has-ansi": "2.0.0",
+								"strip-ansi": "3.0.1",
+								"supports-color": "2.0.0"
 							}
 						},
 						"strip-ansi": {
@@ -4382,7 +4382,7 @@
 							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^2.0.0"
+								"ansi-regex": "2.1.1"
 							}
 						}
 					}
@@ -4393,7 +4393,7 @@
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"js-tokens": {
@@ -4408,7 +4408,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
@@ -4431,12 +4431,12 @@
 					"integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
 					"dev": true,
 					"requires": {
-						"ajv": "^5.2.3",
-						"ajv-keywords": "^2.1.0",
-						"chalk": "^2.1.0",
-						"lodash": "^4.17.4",
+						"ajv": "5.5.2",
+						"ajv-keywords": "2.1.1",
+						"chalk": "2.4.2",
+						"lodash": "4.17.15",
 						"slice-ansi": "1.0.0",
-						"string-width": "^2.1.1"
+						"string-width": "2.1.1"
 					}
 				}
 			}
@@ -4824,9 +4824,9 @@
 			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
 			"dev": true,
 			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
+				"chardet": "0.4.2",
+				"iconv-lite": "0.4.24",
+				"tmp": "0.0.33"
 			}
 		},
 		"extglob": {
@@ -5734,8 +5734,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -5756,14 +5755,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -5778,20 +5775,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5908,8 +5902,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5921,7 +5914,6 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -5936,7 +5928,6 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -5944,14 +5935,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "5.1.2",
 						"yallist": "3.0.3"
@@ -5970,7 +5959,6 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -6051,8 +6039,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -6064,7 +6051,6 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -6150,8 +6136,7 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -6187,7 +6172,6 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -6207,7 +6191,6 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "2.1.1"
 					}
@@ -6251,14 +6234,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -6877,20 +6858,20 @@
 			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
+				"ansi-escapes": "3.2.0",
+				"chalk": "2.4.2",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.2.0",
+				"figures": "2.0.0",
+				"lodash": "4.17.15",
 				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"through": "2.3.8"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6905,7 +6886,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -13245,8 +13226,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "^0.1.0",
-				"resolve-from": "^1.0.0"
+				"caller-path": "0.1.0",
+				"resolve-from": "1.0.1"
 			}
 		},
 		"requizzle": {
@@ -13409,7 +13390,7 @@
 			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
 			"dev": true,
 			"requires": {
-				"rx-lite": "*"
+				"rx-lite": "4.0.8"
 			}
 		},
 		"rxjs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vlitejs",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"description": "vLitejs is a fast and lightweight Javascript library for customizing HTML5 and Youtube video players in Javascript with a minimalist theme",
 	"keywords": [
 		"html5",
@@ -65,7 +65,6 @@
 		"webpack-manifest-plugin": "2.0.3"
 	},
 	"engines": {
-		"node": "8.11.2",
-		"npm": "5.6.0"
+		"node": ">=8.11.2"
 	}
 }

--- a/src/vlite/js/vlite.js
+++ b/src/vlite/js/vlite.js
@@ -1,7 +1,7 @@
 /**
 * @license MIT
 * @name vlitejs
-* @version 3.0.2
+* @version 3.0.3
 * @author: Yoriiis aka Joris DANIEL <joris.daniel@gmail.com>
 * @description: vLitejs is a fast and lightweight Javascript library for customizing HTML5 and Youtube video players in Javascript with a minimalist theme
 * {@link https://yoriiis.github.io/vlitejs}


### PR DESCRIPTION
This fixes the case where node engine is strict in the package.json. Updated it with a minimal version of `8.11.2` (issue #6).