### PR TITLE
fix vlite halts native keyboard events when using HTML input Elements

### DIFF
--- a/src/vlite/assets/scripts/vlite.ts
+++ b/src/vlite/assets/scripts/vlite.ts
@@ -240,8 +240,7 @@ class Vlitejs {
 		const formTags = ['input', 'textarea', 'select']
 		if (
 			formTags.includes(target.nodeName.toLowerCase()) ||
-			target.matches('[contenteditable]') ||
-			(target as any).msMatchesSelector('[contenteditable]')
+			target.matches('[contenteditable]')
 		) {
 			return
 		}


### PR DESCRIPTION
When vlitejs is implemented on a page where also input Elements are located you are unable to use these form inputs.
This is especially an issue when trying to type something for example inside a text input. You are not allowed to type spaces, move backwards or forwards in text and so on.

**Quick Example:**
https://jsfiddle.net/2b0uxmew/4/

