### PR TITLE
Add style to CSS exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 			"import": "./dist/plugins/*.js"
 		},
 		"./plugins/*.css": {
+			"style": "./dist/plugins/*.css",
 			"import": "./dist/plugins/*.css"
 		},
 		"./providers/*": {
@@ -54,6 +55,7 @@
 			"import": "./dist/providers/*.js"
 		},
 		"./vlite.css": {
+			"style": "./dist/vlite.css",
 			"import": "./dist/vlite.css"
 		},
 		".": {


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

With CSS files exported in `package.json`, the `style` field is needed.

Related: https://github.com/webpack/enhanced-resolve/issues/494