### PR TITLE
Fix control bar not display on first tap without mobile plugin

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -51,7 +51,7 @@
 				"@rollup/plugin-buble": "^1.0.3",
 				"@rollup/plugin-node-resolve": "^16.0.3",
 				"@rollup/plugin-replace": "^6.0.3",
-				"@rollup/plugin-terser": "^0.4.4",
+				"@rollup/plugin-terser": "^1.0.0",
 				"@rollup/plugin-typescript": "^12.3.0",
 				"@types/chromecast-caf-sender": "^1.0.11",
 				"postcss": "^8.5.6",

--- a/src/core/vlite.ts
+++ b/src/core/vlite.ts
@@ -222,6 +222,18 @@ class Vlitejs {
 			nodeName: ['div']
 		})
 
+		// Touch device: overlay tap shows the control bar when hidden (no regression without mobile plugin)
+		if (
+			validateTargetOverlay &&
+			isTouch() &&
+			this.autoHideGranted &&
+			this.player.elements.controlBar?.classList.contains('v-hidden')
+		) {
+			this.stopAutoHideTimer()
+			this.startAutoHideTimer()
+			return
+		}
+
 		// Touch device will not toggle playback, only display the control bar
 		if (validateTargetPlayPauseButton || (validateTargetOverlay && !isTouch())) {
 			this.player.controlBar.togglePlayPause(e)

--- a/src/plugins/mobile/mobile.ts
+++ b/src/plugins/mobile/mobile.ts
@@ -38,7 +38,9 @@ export default class Mobile {
 	 * Add event listeners
 	 */
 	addEvents() {
-		this.player.elements.container.addEventListener('click', this.onClickOnContainer)
+		this.player.elements.container.addEventListener('click', this.onClickOnContainer, {
+			capture: true
+		})
 	}
 
 	/**
@@ -77,6 +79,8 @@ export default class Mobile {
 	 * Destroy the plugin
 	 */
 	destroy() {
-		this.player.elements.container.removeEventListener('click', this.onClickOnContainer)
+		this.player.elements.container.removeEventListener('click', this.onClickOnContainer, {
+			capture: true
+		})
 	}
 }


### PR DESCRIPTION
Regression from https://github.com/vlitejs/vlite/pull/194/changes#diff-408d0ca2ce8a0d1d973d9d661486c0ec68f56d57f18af894f24040d2b4d8bec0R201