### PR TITLE
Fix volume thumb position on mouse leave

### DIFF
--- a/src/plugins/volume-bar/volume-bar.css
+++ b/src/plugins/volume-bar/volume-bar.css
@@ -12,6 +12,7 @@
 		overflow: hidden;
 		width: 0;
 		height: 25px;
+		max-height: calc(var(--vlite-progressBarHeight) * 2);
 
 		&:focus-visible {
 			width: 52px;


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

On mouse leave of volume control, the volume thumb go up. Fix this issue.

Fix #149