### PR TITLE
Fix time format

### DIFF
--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -15,17 +15,14 @@ declare global {
  * @returns Formatted time
  */
 export function formatVideoTime(time: number): string {
-	const ms = time * 1000
-	const min = (ms / 1000 / 60) << 0
-	const sec = ((ms / 1000) % 60) << 0
-	let timeInString = ''
+	const hour = Math.floor(time / 3600)
+	const min = Math.floor((time % 3600) / 60)
+	const sec = Math.floor(time % 60)
 
-	timeInString += min < 10 ? '0' : ''
-	timeInString += `${min}:`
-	timeInString += sec < 10 ? '0' : ''
-	timeInString += sec
-
-	return timeInString
+	if (hour > 0) {
+		return hour + ':' + (min < 10 ? `0${min}` : min) + ':' + (sec < 10 ? `0${sec}` : sec)
+	}
+	return min + ':' + (sec < 10 ? `0${sec}` : sec)
 }
 
 /**

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -10,7 +10,14 @@ declare global {
 }
 
 /**
- * Convert video time second to 00:00 display
+ * Convert video time second to 0:00 display
+ * 
+ * E.g.:
+ * - 0 → 0:00
+ * - 65 → 1:05
+ * - 3600 → 1:00:00
+ * - 3665 → 1:01:05
+ * - 96520 → 26:48:40
  * @param time Current time
  * @returns Formatted time
  */

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -11,7 +11,7 @@ declare global {
 
 /**
  * Convert video time second to 0:00 display
- * 
+ *
  * E.g.:
  * - 0 → 0:00
  * - 65 → 1:05

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -20,9 +20,10 @@ export function formatVideoTime(time: number): string {
 	const sec = Math.floor(time % 60)
 
 	if (hour > 0) {
-		return hour + ':' + (min < 10 ? `0${min}` : min) + ':' + (sec < 10 ? `0${sec}` : sec)
+		return `${hour}:${min < 10 ? `0${min}` : min}:${sec < 10 ? `0${sec}` : sec}`
 	}
-	return min + ':' + (sec < 10 ? `0${sec}` : sec)
+
+	return `${min}:${sec < 10 ? `0${sec}` : sec}`
 }
 
 /**


### PR DESCRIPTION
This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Current time implementation doesn't handle hours and doesn't pad the 0 of the first digit (hour or minutes)

### 

| Before | After
| - | -
|<img width="273" height="40" alt="image" src="https://github.com/user-attachments/assets/e9aecdd2-919e-4cc7-98c9-0b38b2ad64ef" /> | <img width="253" height="45" alt="image" src="https://github.com/user-attachments/assets/a7552b5c-98a8-4e94-b1c6-494935a27200" />
|<img width="262" height="48" alt="image" src="https://github.com/user-attachments/assets/63a6af57-a0c8-4d7b-b1d0-1d5649d6afcf" />|<img width="253" height="46" alt="image" src="https://github.com/user-attachments/assets/4f7b3706-3f9c-444a-821d-dfc2761eb442" />
|<img width="267" height="46" alt="image" src="https://github.com/user-attachments/assets/9126b98b-7998-441f-ada5-359bfd7b233e" />|<img width="283" height="49" alt="image" src="https://github.com/user-attachments/assets/bbd77797-0dfd-4113-94c4-0a745430c486" />

<html><body>
<!--StartFragment-->

| Seconds | Output
| - | -
| 0 | 0:00
| 65 | 1:05
| 3600 | 1:00:00
| 3665 | 1:01:05
| 96520 | 26:48:40