### PR TITLE
feat(subtitle): add provider caption support for vimeo, dailymotion and youtube

### DIFF
--- a/examples/dailymotion/config.js
+++ b/examples/dailymotion/config.js
@@ -1,6 +1,8 @@
 import 'vlitejs/vlite.css'
 import 'vlitejs/plugins/volume-bar.css'
+import 'vlitejs/plugins/subtitle.css'
 import Vlitejs from 'vlitejs'
+import VlitejsSubtitle from 'vlitejs/plugins/subtitle.js'
 import VlitejsVolumeBar from 'vlitejs/plugins/volume-bar.js'
 import VlitejsDailymotion from 'vlitejs/providers/dailymotion.js'
 import { changeSourceEvent } from '../shared/utils.js'
@@ -8,6 +10,7 @@ import { changeSourceEvent } from '../shared/utils.js'
 Vlitejs.registerProvider('dailymotion', VlitejsDailymotion, {
 	playerId: 'x9scg'
 })
+Vlitejs.registerPlugin('subtitle', VlitejsSubtitle)
 Vlitejs.registerPlugin('volume-bar', VlitejsVolumeBar)
 
 new Vlitejs('#player', {
@@ -27,7 +30,7 @@ new Vlitejs('#player', {
 		autoHide: true
 	},
 	provider: 'dailymotion',
-	plugins: ['volume-bar'],
+	plugins: ['subtitle', 'volume-bar'],
 	onReady: (player) => {
 		console.log(player)
 
@@ -40,6 +43,8 @@ new Vlitejs('#player', {
 		player.on('enterfullscreen', () => console.log('enterfullscreen'))
 		player.on('exitfullscreen', () => console.log('exitfullscreen'))
 		player.on('ended', () => console.log('ended'))
+		player.on('trackenabled', () => console.log('trackenabled'))
+		player.on('trackdisabled', () => console.log('trackdisabled'))
 
 		changeSourceEvent({ player })
 	}

--- a/examples/dailymotion/index.html
+++ b/examples/dailymotion/index.html
@@ -8,7 +8,7 @@
 		<!-- CSS and JavaScript files are automatically injected by the HtmlWebpackPlugin -->
 	</head>
 	<body>
-		<div id="player" data-dailymotion-id="x88trc6"></div>
+		<div id="player" data-dailymotion-id="x8bi4nd"></div>
 		<%= require('html-loader!../shared/change-source.html').default %>
 	</body>
 </html>

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -93,7 +93,6 @@
 			"integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -136,7 +135,6 @@
 			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/parser": "^7.28.5",
 				"@babel/types": "^7.28.5",
@@ -154,7 +152,6 @@
 			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.27.2",
 				"@babel/helper-validator-option": "^7.27.1",
@@ -172,7 +169,6 @@
 			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -183,7 +179,6 @@
 			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/traverse": "^7.27.1",
 				"@babel/types": "^7.27.1"
@@ -198,7 +193,6 @@
 			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.27.1",
 				"@babel/helper-validator-identifier": "^7.27.1",
@@ -217,7 +211,6 @@
 			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -238,7 +231,6 @@
 			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -249,7 +241,6 @@
 			"integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.27.2",
 				"@babel/types": "^7.28.4"
@@ -264,7 +255,6 @@
 			"integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.28.5"
 			},
@@ -281,7 +271,6 @@
 			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/parser": "^7.27.2",
@@ -297,7 +286,6 @@
 			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -317,7 +305,6 @@
 			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
 				"@babel/helper-validator-identifier": "^7.28.5"
@@ -462,6 +449,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -485,6 +473,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1632,7 +1621,6 @@
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -2189,6 +2177,7 @@
 			"integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -2546,6 +2535,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2585,6 +2575,7 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -2912,6 +2903,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -3302,8 +3294,7 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
@@ -4463,7 +4454,6 @@
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -5229,7 +5219,6 @@
 			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -5257,7 +5246,6 @@
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -5373,7 +5361,6 @@
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
@@ -6056,6 +6043,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -7331,6 +7319,7 @@
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -8728,7 +8717,8 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/tsyringe": {
 			"version": "4.10.0",
@@ -8770,6 +8760,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -8911,6 +8902,7 @@
 			"integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -8960,6 +8952,7 @@
 			"integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.6.1",
 				"@webpack-cli/configtest": "^3.0.1",
@@ -9248,8 +9241,7 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/yn": {
 			"version": "3.1.1",

--- a/examples/vimeo/config.js
+++ b/examples/vimeo/config.js
@@ -1,11 +1,14 @@
 import 'vlitejs/vlite.css'
 import 'vlitejs/plugins/volume-bar.css'
+import 'vlitejs/plugins/subtitle.css'
 import Vlitejs from 'vlitejs'
+import VlitejsSubtitle from 'vlitejs/plugins/subtitle.js'
 import VlitejsVolumeBar from 'vlitejs/plugins/volume-bar.js'
 import VlitejsVimeo from 'vlitejs/providers/vimeo.js'
 import { changeSourceEvent } from '../shared/utils.js'
 
 Vlitejs.registerProvider('vimeo', VlitejsVimeo)
+Vlitejs.registerPlugin('subtitle', VlitejsSubtitle)
 Vlitejs.registerPlugin('volume-bar', VlitejsVolumeBar)
 
 new Vlitejs('#player', {
@@ -26,7 +29,7 @@ new Vlitejs('#player', {
 		providerParams: {}
 	},
 	provider: 'vimeo',
-	plugins: ['volume-bar'],
+	plugins: ['subtitle', 'volume-bar'],
 	onReady: (player) => {
 		console.log(player)
 
@@ -39,6 +42,8 @@ new Vlitejs('#player', {
 		player.on('enterfullscreen', () => console.log('enterfullscreen'))
 		player.on('exitfullscreen', () => console.log('exitfullscreen'))
 		player.on('ended', () => console.log('ended'))
+		player.on('trackenabled', () => console.log('trackenabled'))
+		player.on('trackdisabled', () => console.log('trackdisabled'))
 
 		changeSourceEvent({ player })
 	}

--- a/examples/vimeo/index.html
+++ b/examples/vimeo/index.html
@@ -7,7 +7,7 @@
 		<!-- CSS and JavaScript files are automatically injected by the HtmlWebpackPlugin -->
 	</head>
 	<body>
-		<div id="player" data-vimeo-id="162391385"></div>
+		<div id="player" data-vimeo-id="1087658066"></div>
 		<%= require('html-loader!../shared/change-source.html').default %>
 	</body>
 </html>

--- a/examples/youtube/config.js
+++ b/examples/youtube/config.js
@@ -1,11 +1,14 @@
 import 'vlitejs/vlite.css'
 import 'vlitejs/plugins/volume-bar.css'
+import 'vlitejs/plugins/subtitle.css'
 import Vlitejs from 'vlitejs'
+import VlitejsSubtitle from 'vlitejs/plugins/subtitle.js'
 import VlitejsVolumeBar from 'vlitejs/plugins/volume-bar.js'
 import VlitejsYoutube from 'vlitejs/providers/youtube.js'
 import { changeSourceEvent } from '../shared/utils.js'
 
 Vlitejs.registerProvider('youtube', VlitejsYoutube)
+Vlitejs.registerPlugin('subtitle', VlitejsSubtitle)
 Vlitejs.registerPlugin('volume-bar', VlitejsVolumeBar)
 
 new Vlitejs('#player', {
@@ -26,7 +29,7 @@ new Vlitejs('#player', {
 		providerParams: {}
 	},
 	provider: 'youtube',
-	plugins: ['volume-bar'],
+	plugins: ['subtitle', 'volume-bar'],
 	onReady: (player) => {
 		console.log(player)
 

--- a/examples/youtube/index.html
+++ b/examples/youtube/index.html
@@ -8,7 +8,7 @@
 		<!-- CSS and JavaScript files are automatically injected by the HtmlWebpackPlugin -->
 	</head>
 	<body>
-		<div id="player" data-youtube-id="43TH3PKNc_c"></div>
+		<div id="player" data-youtube-id="8X2kIfS6fb8"></div>
 		<%= require('html-loader!../shared/change-source.html').default %>
 	</body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -301,6 +301,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -322,6 +323,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -426,6 +428,7 @@
 			"version": "7.1.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -831,6 +834,7 @@
 			"version": "7.1.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -1997,6 +2001,7 @@
 			"version": "8.15.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2111,6 +2116,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.19",
 				"caniuse-lite": "^1.0.30001751",
@@ -2146,6 +2152,7 @@
 			"version": "6.4.2",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2435,6 +2442,7 @@
 			"version": "7.1.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -3026,6 +3034,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
@@ -3758,6 +3767,7 @@
 			"version": "7.1.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -4111,6 +4121,7 @@
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -4896,12 +4907,14 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true,
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/src/plugins/subtitle/README.md
+++ b/src/plugins/subtitle/README.md
@@ -10,7 +10,7 @@ Supports for multiple caption tracks (VTT).
 | Path             | `vlitejs/plugins/subtitle`              |
 | Entry point      | `vlitejs/plugins/subtitle/subtitle.js`  |
 | Stylesheet       | `vlitejs/plugins/subtitle/subtitle.css` |
-| Provider&sup2;   | `'html5'`                               |
+| Provider&sup2;   | `'html5', 'vimeo', 'dailymotion', 'youtube'` |
 | Media type&sup3; | `'video'`                               |
 
 ## Usage
@@ -39,14 +39,77 @@ new Vlitejs('#player', {
 });
 ```
 
+### JavaScript (Vimeo)
+
+```js
+import 'vlitejs/vlite.css';
+import 'vlitejs/plugins/subtitle.css';
+import Vlitejs from 'vlitejs';
+import VlitejsSubtitle from 'vlitejs/plugins/subtitle.js';
+import VlitejsVimeo from 'vlitejs/providers/vimeo.js';
+
+Vlitejs.registerProvider('vimeo', VlitejsVimeo);
+Vlitejs.registerPlugin('subtitle', VlitejsSubtitle);
+
+new Vlitejs('#player', {
+  provider: 'vimeo',
+  plugins: ['subtitle']
+});
+```
+
+> [!NOTE]
+> For Vimeo, captions are rendered inside the Vimeo iframe. The subtitle button and menu control which track is active, but the visual rendering is handled by Vimeo's player. Captions availability depends on the video's caption track configuration on Vimeo.
+
+### JavaScript (Dailymotion)
+
+```js
+import 'vlitejs/vlite.css';
+import 'vlitejs/plugins/subtitle.css';
+import Vlitejs from 'vlitejs';
+import VlitejsSubtitle from 'vlitejs/plugins/subtitle.js';
+import VlitejsDailymotion from 'vlitejs/providers/dailymotion.js';
+
+Vlitejs.registerProvider('dailymotion', VlitejsDailymotion, { playerId: 'x9scg' });
+Vlitejs.registerPlugin('subtitle', VlitejsSubtitle);
+
+new Vlitejs('#player', {
+  provider: 'dailymotion',
+  plugins: ['subtitle']
+});
+```
+
+> [!NOTE]
+> For Dailymotion, captions are rendered inside the Dailymotion iframe. Language labels are derived from language codes using the browser's `Intl.DisplayNames` API. Captions availability depends on the video's subtitle track configuration on Dailymotion.
+
+### JavaScript (YouTube)
+
+```js
+import 'vlitejs/vlite.css';
+import 'vlitejs/plugins/subtitle.css';
+import Vlitejs from 'vlitejs';
+import VlitejsSubtitle from 'vlitejs/plugins/subtitle.js';
+import VlitejsYoutube from 'vlitejs/providers/youtube.js';
+
+Vlitejs.registerProvider('youtube', VlitejsYoutube);
+Vlitejs.registerPlugin('subtitle', VlitejsSubtitle);
+
+new Vlitejs('#player', {
+  provider: 'youtube',
+  plugins: ['subtitle']
+});
+```
+
+> [!NOTE]
+> For YouTube, captions are rendered inside the YouTube iframe. The subtitle button appears after the YouTube captions module becomes available, which typically requires the video to start playing. Captions availability depends on the video's caption track configuration on YouTube.
+
 ## Events
 
 The plugin exposes the following native `Event` on the `.v-vlite` element.
 
 | Event Type      | Description                                |
 | --------------- | ------------------------------------------ |
-| `trackenabled`  | Sent when a track is enabled and displayed |
-| `trackdisabled` | Sent when a track is disabled and hidden   |
+| `trackenabled`  | Sent when a track is enabled             |
+| `trackdisabled` | Sent when a track is disabled            |
 
 ## Demo
 

--- a/src/plugins/subtitle/subtitle.ts
+++ b/src/plugins/subtitle/subtitle.ts
@@ -6,19 +6,33 @@ import type { pluginParameter } from 'shared/assets/types/types.js'
 import validateTarget from 'shared/utils/validate-target.js'
 
 /**
+ * Normalized text track shape used across HTML5 and provider paths.
+ */
+type NormalizedTextTrack = {
+	language: string
+	label: string
+	kind: string
+	mode: string
+	cues?: TextTrackCueList | null
+	activeCues?: TextTrackCueList | null
+}
+
+/**
  * Vlitejs Subtitle plugin
  * @module Vlitejs/plugins/subtitle
  */
 export default class Subtitle {
 	player: any
-	tracks: TextTrack[]
-	activeTrack!: TextTrack | null
+	tracks: NormalizedTextTrack[]
+	activeTrack: NormalizedTextTrack | null
+	supportsProviderTextTracks: boolean
+	providerTracksInitialized: boolean
 	captions!: HTMLElement
 	subtitleButton!: HTMLElement
 	subtitlesList!: HTMLElement
 	subtitlesListCssTransitionDuration: number
 
-	providers = ['html5']
+	providers = ['html5', 'vimeo', 'dailymotion', 'youtube']
 	types = ['video']
 
 	/**
@@ -28,7 +42,19 @@ export default class Subtitle {
 	 */
 	constructor({ player }: pluginParameter) {
 		this.player = player
-		this.tracks = Array.from(this.player.media.textTracks)
+		this.supportsProviderTextTracks =
+			typeof this.player.getTextTracks === 'function' &&
+			typeof this.player.enableTextTrack === 'function'
+		this.providerTracksInitialized = false
+
+		if (this.supportsProviderTextTracks) {
+			this.tracks = []
+			this.activeTrack = null
+		} else {
+			this.tracks = Array.from(this.player.media.textTracks) as NormalizedTextTrack[]
+			this.activeTrack = null
+		}
+
 		this.subtitlesListCssTransitionDuration = 0
 
 		this.onClickOnSubtitleButton = this.onClickOnSubtitleButton.bind(this)
@@ -37,24 +63,31 @@ export default class Subtitle {
 	}
 
 	/**
+	 * Cache DOM elements and compute the subtitles list transition duration
+	 */
+	cacheDomElements() {
+		this.captions = this.player.elements.container.querySelector('.v-captions') as HTMLElement
+		this.subtitleButton = this.player.elements.container.querySelector(
+			'.v-subtitleButton'
+		) as HTMLElement
+		this.subtitlesList = this.player.elements.container.querySelector(
+			'.v-subtitlesList'
+		) as HTMLElement
+		this.subtitlesListCssTransitionDuration =
+			Number.parseFloat(window.getComputedStyle(this.subtitlesList).transitionDuration) * 1000
+	}
+
+	/**
 	 * Initialize
 	 */
 	init() {
-		if (this.tracks.length && this.player.options.controls) {
-			this.activeTrack = this.getActiveTrack()
+		if (!this.supportsProviderTextTracks && this.tracks.length && this.player.options.controls) {
+			this.activeTrack = this.getActiveTrack() ?? null
 
 			this.hideTracks()
 			this.render()
 
-			this.captions = this.player.elements.container.querySelector('.v-captions') as HTMLElement
-			this.subtitleButton = this.player.elements.container.querySelector(
-				'.v-subtitleButton'
-			) as HTMLElement
-			this.subtitlesList = this.player.elements.container.querySelector(
-				'.v-subtitlesList'
-			) as HTMLElement
-			this.subtitlesListCssTransitionDuration =
-				Number.parseFloat(window.getComputedStyle(this.subtitlesList).transitionDuration) * 1000
+			this.cacheDomElements()
 
 			this.addEvents()
 		}
@@ -64,14 +97,43 @@ export default class Subtitle {
 	 * On player ready
 	 */
 	onReady() {
-		this.enableTrack()
+		if (this.supportsProviderTextTracks) {
+			this.initProviderTextTracks()
+			this.player.on('texttracksready', () => {
+				if (!this.providerTracksInitialized) {
+					this.initProviderTextTracks()
+				}
+			})
+		} else {
+			this.enableTrack()
+		}
+	}
+
+	/**
+	 * Initialize provider-backed text tracks (Vimeo SDK)
+	 * Fetches tracks asynchronously, then renders the UI if tracks are available
+	 */
+	initProviderTextTracks() {
+		this.player.getTextTracks().then((tracks: NormalizedTextTrack[]) => {
+			if (this.providerTracksInitialized) return
+
+			this.tracks = tracks
+
+			if (this.tracks.length && this.player.options.controls) {
+				this.render()
+				this.cacheDomElements()
+				this.addEvents()
+				this.enableTrack()
+				this.providerTracksInitialized = true
+			}
+		})
 	}
 
 	/**
 	 * Get the default track or the first one if no match
 	 * @returns Active track
 	 */
-	getActiveTrack(): TextTrack {
+	getActiveTrack(): NormalizedTextTrack | undefined {
 		return this.tracks.find((track) => track.mode === 'showing') || this.tracks[0]
 	}
 
@@ -131,27 +193,27 @@ export default class Subtitle {
 	 */
 	getTemplate(): string {
 		return `
-				<div class="v-subtitle">
-					<button class="v-subtitleButton v-controlButton v-controlPressed">
-						${svgSubtitleOn}${svgSubtitleOff}
-					</button>
-					<div class="v-subtitlesList">
-						<ul>
-							<li>
-								<button class="v-trackButton v-active" data-language="off">${svgCheck}Off</button>
-							</li>
-							${this.tracks
-								.map(
-									(track) =>
-										`<li>
-											<button class="v-trackButton" data-language="${track.language}">${svgCheck}${track.label}</button>
-										</li>`
-								)
-								.join(' ')}
-						</ul>
-					</div>
+			<div class="v-subtitle">
+				<button class="v-subtitleButton v-controlButton v-controlPressed">
+					${svgSubtitleOn}${svgSubtitleOff}
+				</button>
+				<div class="v-subtitlesList">
+					<ul>
+						<li>
+							<button class="v-trackButton v-active" data-language="off">${svgCheck}Off</button>
+						</li>
+						${this.tracks
+							.map(
+								(track) =>
+									`<li>
+										<button class="v-trackButton" data-language="${track.language}">${svgCheck}${track.label}</button>
+									</li>`
+							)
+							.join(' ')}
+					</ul>
 				</div>
-			`
+			</div>
+		`
 	}
 
 	/**
@@ -160,7 +222,9 @@ export default class Subtitle {
 	addEvents() {
 		this.subtitleButton.addEventListener('click', this.onClickOnSubtitleButton)
 		this.subtitlesList.addEventListener('click', this.onClickOnSubtitlesList)
-		this.player.media.addEventListener('ended', this.onMediaEnded)
+		if (!this.supportsProviderTextTracks) {
+			this.player.media.addEventListener('ended', this.onMediaEnded)
+		}
 	}
 
 	/**
@@ -196,13 +260,26 @@ export default class Subtitle {
 
 			if (language === 'off') {
 				this.subtitleButton.classList.add('v-controlPressed')
-				this.captions.classList.remove('v-active')
-				this.captions.innerHTML = ''
-				this.activeTrack && this.updateCues({ isDisabled: true })
+				if (this.supportsProviderTextTracks) {
+					this.player.disableTextTrack()
+					this.player.dispatchEvent('trackdisabled')
+				} else {
+					this.captions.classList.remove('v-active')
+					this.captions.innerHTML = ''
+					this.activeTrack && this.updateCues({ isDisabled: true })
+				}
 			} else {
 				this.subtitleButton.classList.remove('v-controlPressed')
-				this.activeTrack = this.getTrackByLanguage(language)
-				this.activeTrack && this.updateCues()
+				if (this.supportsProviderTextTracks) {
+					this.activeTrack = this.getTrackByLanguage(language)
+					if (this.activeTrack) {
+						this.player.enableTextTrack(this.activeTrack.language, this.activeTrack.kind)
+						this.player.dispatchEvent('trackenabled')
+					}
+				} else {
+					this.activeTrack = this.getTrackByLanguage(language)
+					this.activeTrack && this.updateCues()
+				}
 			}
 
 			triggerPlayerFocus && this.player.elements.container.focus()
@@ -216,7 +293,7 @@ export default class Subtitle {
 	 * @param language Language of the track
 	 * @returns TextTrack for the current language
 	 */
-	getTrackByLanguage(language: string): TextTrack | null {
+	getTrackByLanguage(language: string): NormalizedTextTrack | null {
 		return this.tracks.find((track) => track.language === language) || null
 	}
 
@@ -227,7 +304,7 @@ export default class Subtitle {
 	 */
 	updateCues({ isDisabled = false }: { isDisabled?: boolean } = {}) {
 		if (this.activeTrack?.cues?.length) {
-			const cues = Array.from(this.activeTrack.cues)
+			const cues = Array.from(this.activeTrack.cues) as TextTrackCue[]
 			const activeCues = this.activeTrack.activeCues
 
 			const _this = this

--- a/src/providers/dailymotion/dailymotion.ts
+++ b/src/providers/dailymotion/dailymotion.ts
@@ -78,7 +78,8 @@ export default function DailymotionProvider(Player: any, options: interfaceProvi
 				{ type: 'timeupdate', listener: super.onTimeUpdate },
 				{ type: 'end', listener: super.onMediaEnded },
 				{ type: 'playing', listener: this.onPlaying },
-				{ type: 'waiting', listener: this.onWaiting }
+				{ type: 'waiting', listener: this.onWaiting },
+				{ type: 'subtitlesavailable', listener: this.onSubtitlesAvailable }
 			]
 		}
 
@@ -289,6 +290,14 @@ export default function DailymotionProvider(Player: any, options: interfaceProvi
 		 */
 		methodSeekTo(newTime: number) {
 			this.instance.seek(newTime)
+		}
+
+		/**
+		 * Function executed when subtitles become available
+		 * Subtitles load asynchronously after playback starts
+		 */
+		onSubtitlesAvailable() {
+			this.dispatchEvent('texttracksready')
 		}
 
 		/**

--- a/src/providers/dailymotion/dailymotion.ts
+++ b/src/providers/dailymotion/dailymotion.ts
@@ -1,5 +1,15 @@
 import type { configEvent, playerParameters } from 'shared/assets/types/types.js'
 
+/**
+ * Normalized text track shape shared across providers.
+ */
+type NormalizedTextTrack = {
+	language: string
+	label: string
+	kind: string
+	mode: string
+}
+
 declare global {
 	interface Window {
 		Vlitejs: {
@@ -141,6 +151,62 @@ export default function DailymotionProvider(Player: any, options: interfaceProvi
 		 */
 		getInstance(): any {
 			return this.instance
+		}
+
+		/**
+		 * Get the available text tracks
+		 * @returns Normalized text tracks
+		 */
+		getTextTracks(): Promise<NormalizedTextTrack[]> {
+			return new window.Promise((resolve) => {
+				this.instance.getState().then((state: any) => {
+					const codes: string[] = state.videoSubtitlesList || []
+					let displayNames: any = null
+					try {
+						displayNames = new (Intl as any).DisplayNames([navigator.language], {
+							type: 'language'
+						})
+					} catch {
+						displayNames = null
+					}
+					resolve(
+						codes.map((code) => {
+							let label = code
+							if (displayNames) {
+								try {
+									label = displayNames.of(code) || code
+								} catch {
+									label = code
+								}
+							}
+							return {
+								language: code,
+								label,
+								kind: 'subtitles',
+								mode: state.videoSubtitles === code ? 'showing' : 'disabled'
+							}
+						})
+					)
+				})
+			})
+		}
+
+		/**
+		 * Enable a text track by language
+		 * @param language Language code of the track
+		 * @param kind Optional track kind
+		 */
+		enableTextTrack(language: string, _kind?: string): Promise<void> {
+			this.instance.setSubtitles(language)
+			return window.Promise.resolve()
+		}
+
+		/**
+		 * Disable all text tracks
+		 */
+		disableTextTrack(): Promise<void> {
+			this.instance.setSubtitles(null)
+			return window.Promise.resolve()
 		}
 
 		/**

--- a/src/providers/vimeo/vimeo.ts
+++ b/src/providers/vimeo/vimeo.ts
@@ -1,5 +1,15 @@
 import type { configEvent, playerParameters } from 'shared/assets/types/types.js'
 
+/**
+ * Normalized text track shape shared across providers.
+ */
+type NormalizedTextTrack = {
+	language: string
+	label: string
+	kind: string
+	mode: string
+}
+
 declare global {
 	interface Window {
 		Vlitejs: {
@@ -125,6 +135,41 @@ export default function VimeoProvider(Player: any) {
 		 */
 		getInstance(): any {
 			return this.instance
+		}
+
+		/**
+		 * Get the available text tracks
+		 * @returns Normalized text tracks
+		 */
+		getTextTracks(): Promise<NormalizedTextTrack[]> {
+			return new window.Promise((resolve) => {
+				this.instance.getTextTracks().then((tracks: any[]) => {
+					resolve(
+						tracks.map((track) => ({
+							language: track.language || '',
+							label: track.label || track.language || '',
+							kind: track.kind || 'subtitles',
+							mode: track.mode || 'disabled'
+						}))
+					)
+				})
+			})
+		}
+
+		/**
+		 * Enable a text track by language
+		 * @param language Language code of the track
+		 * @param kind Optional track kind
+		 */
+		enableTextTrack(language: string, kind?: string): Promise<void> {
+			return this.instance.enableTextTrack(language, kind)
+		}
+
+		/**
+		 * Disable all text tracks
+		 */
+		disableTextTrack(): Promise<void> {
+			return this.instance.disableTextTrack()
 		}
 
 		/**

--- a/src/providers/youtube/youtube.ts
+++ b/src/providers/youtube/youtube.ts
@@ -1,5 +1,15 @@
 import type { playerParameters } from 'shared/assets/types/types.js'
 
+/**
+ * Normalized text track shape shared across providers.
+ */
+type NormalizedTextTrack = {
+	language: string
+	label: string
+	kind: string
+	mode: string
+}
+
 declare global {
 	interface Window {
 		Vlitejs: {
@@ -55,6 +65,8 @@ export default function YoutubeProvider(Player: any) {
 	return class PlayerYoutube extends Player {
 		params: object
 		instance: any
+		captionsModuleReady: Promise<any>
+		captionsModuleResolve!: (value: any) => void
 
 		constructor(props: playerParameters) {
 			super(props)
@@ -69,6 +81,9 @@ export default function YoutubeProvider(Player: any) {
 				wmode: 'transparent'
 			}
 			this.params = { ...DEFAULT_PARAMS, ...this.options.providerParams }
+			this.captionsModuleReady = new window.Promise((resolve) => {
+				this.captionsModuleResolve = resolve
+			})
 		}
 
 		/**
@@ -111,7 +126,8 @@ export default function YoutubeProvider(Player: any) {
 							this.media = data.target.getIframe()
 							resolve()
 						},
-						onStateChange: (e: Event) => this.onPlayerStateChange(e)
+						onStateChange: (e: Event) => this.onPlayerStateChange(e),
+						onApiChange: () => this.onApiChange()
 					}
 				})
 			})
@@ -158,8 +174,57 @@ export default function YoutubeProvider(Player: any) {
 		 * Get the player instance
 		 * @returns Youtube API instance
 		 */
-		getInstance(): unknown {
+		getInstance(): any {
 			return this.instance
+		}
+
+		/**
+		 * Function executed when the player API modules change (e.g. captions module loaded)
+		 * Resolves the captions module promise so text tracks can be queried
+		 */
+		onApiChange() {
+			const modules = this.instance.getOptions()
+			if (modules && modules.indexOf('captions') !== -1) {
+				this.captionsModuleResolve(true)
+				this.dispatchEvent('texttracksready')
+			}
+		}
+
+		/**
+		 * Get the available text tracks
+		 * @returns Normalized text tracks
+		 */
+		getTextTracks(): Promise<NormalizedTextTrack[]> {
+			return window.Promise.race([
+				this.captionsModuleReady,
+				new window.Promise((resolve) => setTimeout(() => resolve([]), 5000))
+			]).then(() => {
+				const tracklist = this.instance.getOption('captions', 'tracklist') || []
+				return tracklist.map((track: any) => ({
+					language: track.languageCode || '',
+					label: track.displayName || track.languageName || track.languageCode || '',
+					kind: track.kind || 'subtitles',
+					mode: track.is_default ? 'showing' : 'disabled'
+				}))
+			})
+		}
+
+		/**
+		 * Enable a text track by language
+		 * @param language Language code of the track
+		 * @param kind Optional track kind
+		 */
+		enableTextTrack(language: string, _kind?: string): Promise<void> {
+			this.instance.setOption('captions', 'track', { languageCode: language })
+			return window.Promise.resolve()
+		}
+
+		/**
+		 * Disable all text tracks
+		 */
+		disableTextTrack(): Promise<void> {
+			this.instance.setOption('captions', 'track', {})
+			return window.Promise.resolve()
 		}
 
 		/**


### PR DESCRIPTION
## Summary

Extend the subtitle plugin with provider caption support for Vimeo, Dailymotion, and YouTube. Provider captions render inside their iframes via the provider SDK, while HTML5 keeps the native TextTrack API.

## Changes

### Core
- **`src/plugins/subtitle/subtitle.ts`** — Provider-aware two-path model using duck-typed capability probing (`typeof player.getTextTracks === 'function'`). Local `NormalizedTextTrack` type replaces `TextTrack`, extracted `cacheDomElements()` helper, `providerTracksInitialized` guard + `texttracksready` event listener for YouTube/Dailymotion late-load recovery. 
- **`src/providers/vimeo/vimeo.ts`** — `getTextTracks()`, `enableTextTrack()`, `disableTextTrack()` via Vimeo SDK.
- **`src/providers/dailymotion/dailymotion.ts`** — `getTextTracks()` (uses `getState()` → `videoSubtitlesList`, `Intl.DisplayNames` for labels), `enableTextTrack()`, `disableTextTrack()` via Dailymotion SDK. Dispatches `texttracksready` event when captions module loads.
- **`src/providers/youtube/youtube.ts`** — `captionsModuleReady` promise resolved in `onApiChange()`, `getTextTracks()` (race vs 5s timeout), `enableTextTrack()`, `disableTextTrack()` via YouTube IFrame API. Dispatches `texttracksready` event when captions module loads.

### Docs & Examples
- **`src/plugins/subtitle/README.md`** — Updated provider row and Vimeo/Dailymotion/YouTube usage sections.
- **`examples/{vimeo,dailymotion,youtube}/config.js`** — Subtitle plugin registration + `trackenabled`/`trackdisabled` listeners.
- **`examples/{vimeo,dailymotion,youtube}/index.html`** — Updated demo video IDs to captioned content.

## How it works

The subtitle plugin probes the player instance for `getTextTracks` / `enableTextTrack` / `disableTextTrack` methods. If present (Vimeo, Dailymotion, YouTube), it uses the provider SDK path where captions render inside the provider iframe. Otherwise (HTML5), it uses the native `TextTrack` API with the `.v-captions` overlay.

For YouTube, the captions module loads asynchronously (`onApiChange`). The plugin handles this with a `texttracksready` event and re-initializes tracks when the module becomes available.

## Test plan

- [x] `npx @biomejs/biome check` passes on all changed files
- [x] `npx tsc --noEmit` passes (no new errors)
- [x] Manual verification in browser: Vimeo, Dailymotion, YouTube examples show CC button, language list, and rendered captions

## Non-breaking

HTML5 subtitle functionality is unchanged. Provider support is additive — the plugin falls back gracefully when provider methods are absent.