### PR TITLE
Fix broken YouTube player ID in preview

### DIFF
--- a/examples/youtube/index.html
+++ b/examples/youtube/index.html
@@ -8,7 +8,7 @@
 		<!-- CSS and JavaScript files are automatically injected by the HtmlWebpackPlugin -->
 	</head>
 	<body>
-		<div id="player" data-youtube-id="43TH3PKNc_c"></div>
+		<div id="player" data-youtube-id="T_EN03fJIyY"></div>
 		<%= require('html-loader!../shared/change-source.html').default %>
 	</body>
 </html>


### PR DESCRIPTION
<!--
  Please place an x (without) in all [ ] that apply
-->

## 🧩 Problem

In vlite.js.org, Youtube Video Example Video ID says that the video is private

## 📝 Summary of changes

- Change Video ID

## 🧱 Scope

- [ ] Core
- [ ] Plugin
- [ ] Provider
- [ ] Build / tooling
- [X] Docs

## 🔖 Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] Documentation
- [X] Chore / maintenance

## ⚠️ Breaking changes

- [ ] Yes
- [X] No

<!--
If yes, describe the impact:
-->

## 🤖 AI usage

- [X] No AI tools were used
- [ ] AI tools were used

<!-- 
If AI tools were used, please provide details:

- Tools used (e.g. ChatGPT, Copilot, etc.):
- What parts were generated (full files, snippets, tests, docs, etc.):
- What validation was performed (tests, manual review, benchmarks, etc.):

> ⚠️ Contributors remain fully responsible for the correctness, security, and licensing of the code.

## 🧪 How to test

Steps to reproduce / test this change:

1. No Need To Reproduce
2.
3.
 -->

## ⚠️ Risks

- Performance impact? NO
- Backward compatibility issues? NO
- Security implications? NO
- Other potential side effects? NO

## ✅ Checklist

- [X] Code follows project conventions
- [X] Unit tests added or updated when logic changes
- [X] Manual testing performed if applicable
- [X] Documentation updated if needed
- [X] No console logs or debug code left

<!-- 
## 📸 Screenshots (UI changes only)

 -->
